### PR TITLE
Fix feasible attempt calculation when optional costs share resources

### DIFF
--- a/src/lib/rules/__tests__/runner.test.ts
+++ b/src/lib/rules/__tests__/runner.test.ts
@@ -41,6 +41,30 @@ describe("maxFeasibleAttempts", () => {
     expect(maxFeasibleAttempts(inventory, baseRisk, 5, 1, optional)).toBe(3);
     expect(maxFeasibleAttempts(inventory, baseRisk, 5, 0, optional)).toBe(5);
   });
+
+  it("returns all attempts when there are no costs", () => {
+    const freeRisk: RiskConfig = {
+      ...baseRisk,
+      inputs: {},
+    };
+    const inventory = { raw: 0, fine: 0, fused: 0, superior: 0, supreme: 0, rawAE: 0 };
+    expect(maxFeasibleAttempts(inventory, freeRisk, 4, 0, undefined)).toBe(4);
+  });
+
+  it("uses combined resource requirements across inputs and optional cost", () => {
+    const sharedResourceRisk: RiskConfig = {
+      ...baseRisk,
+      inputs: { fused: 2 },
+    };
+    const sharedOptional: OptionalCostConfig = {
+      resource: "fused",
+      label: "Extra Fused",
+      perUnitDcReduction: 1,
+      minDc: 10,
+    };
+    const inventory = { raw: 0, fine: 0, fused: 5, superior: 0, supreme: 0, rawAE: 0 };
+    expect(maxFeasibleAttempts(inventory, sharedResourceRisk, 10, 1, sharedOptional)).toBe(1);
+  });
 });
 
 describe("chanceWithAdv", () => {

--- a/src/lib/rules/runner.ts
+++ b/src/lib/rules/runner.ts
@@ -58,16 +58,25 @@ export function totalRequirements(risk: RiskConfig, attempts: number, extraCost:
 }
 
 export function maxFeasibleAttempts(inventory: Inventory, risk: RiskConfig, attempts: number, extraCost: number, optional?: OptionalCostConfig): number {
+  const perAttempt = totalRequirements(risk, 1, extraCost, optional);
   let feasible = attempts;
-  for (const key of Object.keys(risk.inputs) as Resource[]) {
-    const cost = risk.inputs[key] ?? 0;
-    if (cost <= 0) continue;
-    feasible = Math.min(feasible, Math.floor((inventory[key] ?? 0) / cost));
+  let hasCost = false;
+
+  for (const key of Object.keys(perAttempt) as Resource[]) {
+    const cost = perAttempt[key] ?? 0;
+    if (cost <= 0) {
+      continue;
+    }
+
+    hasCost = true;
+    const available = inventory[key] ?? 0;
+    feasible = Math.min(feasible, Math.floor(available / cost));
   }
-  if (optional && extraCost > 0) {
-    const available = inventory[optional.resource] ?? 0;
-    feasible = Math.min(feasible, Math.floor(available / extraCost));
+
+  if (!hasCost) {
+    return Math.max(0, attempts);
   }
+
   return Math.max(0, feasible);
 }
 


### PR DESCRIPTION
## Summary
- derive per-attempt requirements for maxFeasibleAttempts so shared resources are not double counted
- add unit coverage for zero-cost risks and shared input/optional resources

## Testing
- npm test -- --run src/lib/rules/__tests__/runner.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f3d3487e708333a7b837f208559372