### PR TITLE
Add elemental essence subsystem and staged runner support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,56 @@
+import { useEffect, useState } from "react";
+import ElementalEssence from "@/features/elemental/ElementalEssence";
 import NaturalEssence from "@/features/natural/NaturalEssence";
 
+const FAMILY_STORAGE_KEY = "essence-active-family";
+
+type Family = "natural" | "elemental";
+
 function App() {
-  return <NaturalEssence />;
+  const [family, setFamily] = useState<Family>(() => {
+    if (typeof window !== "undefined") {
+      const stored = window.localStorage.getItem(FAMILY_STORAGE_KEY);
+      if (stored === "natural" || stored === "elemental") {
+        return stored;
+      }
+    }
+    return "natural";
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(FAMILY_STORAGE_KEY, family);
+  }, [family]);
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        <div className="flex justify-center gap-3">
+          {(
+            [
+              { id: "natural", label: "Natural" },
+              { id: "elemental", label: "Elemental" },
+            ] as const
+          ).map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setFamily(option.id)}
+              className={`rounded-full border px-5 py-2 text-sm font-medium transition ${
+                family === option.id
+                  ? "border-slate-900 bg-slate-900 text-white"
+                  : "border-slate-300 bg-white text-slate-600 hover:border-slate-500"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <div className="mt-4">
+          {family === "natural" ? <NaturalEssence /> : <ElementalEssence />}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default App;

--- a/src/features/elemental/ElementalEssence.tsx
+++ b/src/features/elemental/ElementalEssence.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import { Dice4, Play, RefreshCw, Undo2 } from "lucide-react";
 import { DiceOverlay, type OverlayEntry } from "@/components/DiceOverlay";
 import { RecentRolls, type RollLogEntry } from "@/components/RecentRolls";
@@ -9,14 +9,13 @@ import {
   computeOdds,
   maxFeasibleAttempts,
   runAction,
-  totalRequirements,
 } from "@/lib/rules/runner";
 import type { ActionConfig, Inventory, Resource, ResourceMap, RollDetail } from "@/lib/rules/types";
-import { NATURAL_ACTIONS } from "./naturalRules";
+import { ELEMENTAL_ACTIONS } from "./elementalRules";
 import type { AdvMode } from "@/lib/rules/types";
 import { clampInt } from "@/lib/rules/probability";
 
-const STORAGE_KEY = "natural-essence-state-v1";
+const STORAGE_KEY = "elemental-essence-state-v1";
 
 interface LogEntry {
   id: string;
@@ -40,6 +39,7 @@ interface Settings {
   traySize: number;
   manualChecks: string;
   manualSalvage: string;
+  toolkit: "standard" | "greater";
 }
 
 interface PersistedState {
@@ -74,6 +74,7 @@ const DEFAULT_SETTINGS: Settings = {
   traySize: 12,
   manualChecks: "",
   manualSalvage: "",
+  toolkit: "standard",
 };
 
 const DEFAULT_STATE: PersistedState = {
@@ -111,6 +112,12 @@ interface ManualQueues {
   salvage: number[];
 }
 
+interface RequirementInfo {
+  static: ResourceMap;
+  optional: ResourceMap;
+  flex: { label: string; amount: number; options: Resource[] }[];
+}
+
 const ROLL_LIMIT = 200;
 const LOG_LIMIT = 200;
 
@@ -138,11 +145,24 @@ const parseInventoryPreset = (input: string): number[] => {
     .map((value) => clampInt(value, 0));
 };
 
-const RESOURCE_ORDER: Resource[] = ["raw", "fine", "fused", "superior", "supreme", "rawAE"];
+const RESOURCE_ORDER: Resource[] = [
+  "rawElemental",
+  "fineElemental",
+  "fusedElemental",
+  "superiorElemental",
+  "supremeElemental",
+  "rawAE",
+  "fineArcane",
+  "raw",
+  "fine",
+  "fused",
+];
+
+const PROGRESSION_TIERS = ["Raw EE", "Fine EE", "Fused EE", "Superior EE", "Supreme EE"];
 
 function buildInitialUiState(): Record<string, ActionUiState> {
   const state: Record<string, ActionUiState> = {};
-  for (const action of NATURAL_ACTIONS) {
+  for (const action of ELEMENTAL_ACTIONS) {
     state[action.id] = {
       riskId: action.risks[0].id,
       batch: 1,
@@ -150,6 +170,33 @@ function buildInitialUiState(): Record<string, ActionUiState> {
     };
   }
   return state;
+}
+
+function buildRequirementInfo(
+  action: ActionConfig,
+  risk: typeof action.risks[number],
+  batch: number,
+  extra: number,
+): RequirementInfo {
+  const staticCost: ResourceMap = {};
+  for (const key of Object.keys(risk.inputs) as Resource[]) {
+    const value = (risk.inputs[key] ?? 0) * batch;
+    if (value) staticCost[key] = value;
+  }
+
+  const optionalCost: ResourceMap = {};
+  if (action.optionalCost && extra > 0) {
+    const cost = extra * batch;
+    optionalCost[action.optionalCost.resource] = cost;
+  }
+
+  const flex = (risk.flexInputs ?? []).map((flexInput) => ({
+    label: flexInput.label,
+    amount: flexInput.amount * batch,
+    options: flexInput.options,
+  }));
+
+  return { static: staticCost, optional: optionalCost, flex };
 }
 
 function inventoryToString(delta: ResourceMap): string {
@@ -224,14 +271,6 @@ function stampRolls(rolls: RollDetail[]): RollLogEntry[] {
   }));
 }
 
-function mergeResourceMap(target: ResourceMap, source: ResourceMap): ResourceMap {
-  const merged: ResourceMap = { ...target };
-  for (const key of Object.keys(source) as Resource[]) {
-    merged[key] = (merged[key] ?? 0) + (source[key] ?? 0);
-  }
-  return merged;
-}
-
 const ActionChip = ({ label, value }: { label: string; value: string }) => (
   <span className="inline-flex min-w-0 items-center gap-1 rounded-full border border-slate-200 bg-white/80 px-2 py-0.5 text-xs text-slate-700">
     <span className="font-medium text-slate-500">{label}</span>
@@ -262,7 +301,7 @@ const NumberField = ({
   </label>
 );
 
-export function NaturalEssence() {
+export function ElementalEssence() {
   const [state, setState] = usePersistentState<PersistedState>(STORAGE_KEY, DEFAULT_STATE);
   const [uiState, setUiState] = useState<Record<string, ActionUiState>>(buildInitialUiState);
   const [message, setMessage] = useState<string | null>(null);
@@ -354,6 +393,11 @@ export function NaturalEssence() {
     const batch = Math.max(1, ui.batch);
     const extra = Math.max(0, ui.extra);
 
+    if (risk.toolRequirement && risk.toolRequirement.id === "greater" && settings.toolkit !== "greater") {
+      showMessage("Greater-grade tools are required for this refinement.");
+      return;
+    }
+
     const feasible = maxFeasibleAttempts(inventory, risk, batch, extra, action.optionalCost);
     if (feasible <= 0) {
       showMessage("Insufficient resources for this action.");
@@ -433,11 +477,13 @@ export function NaturalEssence() {
   };
 
   const inventoryRequirements = useMemo(() => {
-    const requirements: Record<string, ResourceMap> = {};
-    for (const action of NATURAL_ACTIONS) {
+    const requirements: Record<string, RequirementInfo> = {};
+    for (const action of ELEMENTAL_ACTIONS) {
       const ui = uiState[action.id];
       const risk = action.risks.find((item) => item.id === ui.riskId) ?? action.risks[0];
-      requirements[action.id] = totalRequirements(risk, Math.max(1, ui.batch), Math.max(0, ui.extra), action.optionalCost);
+      const batch = Math.max(1, ui.batch);
+      const extra = Math.max(0, ui.extra);
+      requirements[action.id] = buildRequirementInfo(action, risk, batch, extra);
     }
     return requirements;
   }, [uiState]);
@@ -449,42 +495,126 @@ export function NaturalEssence() {
     }));
   };
 
-  const relevantRequirementResources = (requirement?: ResourceMap) =>
-    RESOURCE_ORDER.filter((resource) => (requirement?.[resource] ?? 0) > 0);
-
-  const formatRequirementText = (requirement?: ResourceMap) => {
-    if (!requirement) return "Requires: nothing.";
-    const relevant = relevantRequirementResources(requirement);
-    if (relevant.length === 0) return "Requires: nothing.";
-    const needLine = relevant.map((resource) => `${requirement[resource]} ${RESOURCE_LABELS[resource]}`).join(" & ");
-    const haveLine = relevant.map((resource) => inventory[resource] ?? 0).join(" / ");
-    return `Requires: ${needLine} (have ${haveLine}).`;
+  const relevantRequirementResources = (requirement?: RequirementInfo) => {
+    if (!requirement) return [] as Resource[];
+    const keys = new Set<Resource>();
+    for (const resource of Object.keys(requirement.static) as Resource[]) {
+      if ((requirement.static[resource] ?? 0) > 0) keys.add(resource);
+    }
+    for (const resource of Object.keys(requirement.optional) as Resource[]) {
+      if ((requirement.optional[resource] ?? 0) > 0) keys.add(resource);
+    }
+    return RESOURCE_ORDER.filter((resource) => keys.has(resource));
   };
 
-  const missingResources = (requirement?: ResourceMap) => {
+  const formatRequirementText = (requirement: RequirementInfo | undefined, risk: RiskConfig) => {
+    if (!requirement) return "Requires: nothing.";
+
+    const parts: string[] = [];
+    const staticResources = Object.keys(requirement.static) as Resource[];
+    if (staticResources.length > 0) {
+      const needLine = staticResources
+        .map((resource) => `${requirement.static[resource]} ${RESOURCE_LABELS[resource]}`)
+        .join(" & ");
+      const haveLine = staticResources.map((resource) => inventory[resource] ?? 0).join(" / ");
+      parts.push(`Requires: ${needLine} (have ${haveLine}).`);
+    }
+
+    const optionalResources = Object.keys(requirement.optional) as Resource[];
+    if (optionalResources.length > 0) {
+      const optionalLine = optionalResources
+        .map((resource) => `${requirement.optional[resource]} ${RESOURCE_LABELS[resource]}`)
+        .join(" & ");
+      const haveLine = optionalResources.map((resource) => inventory[resource] ?? 0).join(" / ");
+      parts.push(`Optional: ${optionalLine} (have ${haveLine}).`);
+    }
+
+    for (const flex of requirement.flex) {
+      const optionsLine = flex.options
+        .map((resource) => `${RESOURCE_LABELS[resource]} ${inventory[resource] ?? 0}`)
+        .join(" / ");
+      parts.push(`Flex: ${flex.amount} ${flex.label} [${optionsLine}]`);
+    }
+
+    if (risk.toolRequirement) {
+      parts.push(`Tools: ${risk.toolRequirement.label}`);
+    }
+
+    if (parts.length === 0) {
+      return "Requires: nothing.";
+    }
+
+    return parts.join(" ");
+  };
+
+  const missingResources = (
+    requirement: RequirementInfo | undefined,
+    action: ActionConfig,
+    risk: RiskConfig,
+    batch: number,
+    extra: number,
+  ) => {
     if (!requirement) return [] as string[];
     const missing: string[] = [];
-    for (const resource of relevantRequirementResources(requirement)) {
-      const need = requirement[resource] ?? 0;
+
+    for (const resource of Object.keys(requirement.static) as Resource[]) {
+      const need = requirement.static[resource] ?? 0;
       const have = inventory[resource] ?? 0;
       if (have < need) {
         missing.push(`${need} ${RESOURCE_LABELS[resource]} (have ${have})`);
       }
     }
+
+    for (const resource of Object.keys(requirement.optional) as Resource[]) {
+      const need = requirement.optional[resource] ?? 0;
+      const have = inventory[resource] ?? 0;
+      if (have < need) {
+        missing.push(`${need} ${RESOURCE_LABELS[resource]} (have ${have})`);
+      }
+    }
+
+    if (missing.length === 0) {
+      const feasible = maxFeasibleAttempts(inventory, risk, batch, extra, action.optionalCost);
+      if (feasible < batch) {
+        if ((risk.flexInputs?.length ?? 0) > 0) {
+          missing.push(
+            `Flex supply: ${risk.flexInputs
+              ?.map((flex) => flex.label)
+              .join(", ") ?? "flexible inputs"} insufficient (need ${batch} attempts)`,
+          );
+        } else {
+          missing.push("Insufficient resources for requested batch.");
+        }
+      }
+    }
+
     return missing;
   };
 
-  const renderRequirement = (actionId: string) => {
-    const requirement = inventoryRequirements[actionId];
-    return <div className="text-xs text-slate-600">{formatRequirementText(requirement)}</div>;
+  const renderRequirement = (action: ActionConfig, risk: RiskConfig, info: RequirementInfo | undefined, batch: number, extra: number) => {
+    return (
+      <div className="text-xs text-slate-600">
+        {formatRequirementText(info, risk)}
+        {risk.flexInputs && risk.flexInputs.length > 0 && (
+          <div className="mt-1 text-[11px] text-slate-500">
+            Flex inputs consume from listed resources in any combination per attempt.
+          </div>
+        )}
+        {risk.toolRequirement && settings.toolkit !== "greater" && risk.toolRequirement.id === "greater" && (
+          <div className="mt-1 text-[11px] text-amber-600">Requires greater tools before rolling.</div>
+        )}
+      </div>
+    );
   };
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 p-6">
       <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-slate-900">Natural Essence Crafting</h1>
-          <p className="text-sm text-slate-500">Track inventory, resolve crafting batches, and log your rolls.</p>
+          <h1 className="text-3xl font-bold text-slate-900">Elemental Essence Elevation</h1>
+          <p className="text-sm text-slate-500">
+            Track planar inventory, resolve elemental recipes, and document cross-family infusions with full RawAE auditing.
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
           <span className="rounded-full border border-slate-300 px-3 py-1">Session time: {formatTime(state.sessionMinutes)}</span>
@@ -502,6 +632,22 @@ export function NaturalEssence() {
       {message && <div className="rounded-lg border border-slate-200 bg-white/80 p-3 text-sm text-slate-700">{message}</div>}
 
       <DiceOverlay entries={overlay} />
+
+      <section className="rounded-2xl border border-slate-200 bg-gradient-to-r from-sky-50 to-indigo-50 p-5 shadow-sm backdrop-blur">
+        <h2 className="mb-3 text-lg font-semibold text-slate-800">Elemental progression map</h2>
+        <div className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-700">
+          {PROGRESSION_TIERS.map((tier, index) => (
+            <Fragment key={tier}>
+              <span className="rounded-full border border-slate-300 bg-white/70 px-4 py-1 shadow-sm">{tier}</span>
+              {index < PROGRESSION_TIERS.length - 1 && <span className="text-slate-400">→</span>}
+            </Fragment>
+          ))}
+        </div>
+        <p className="mt-3 text-xs text-slate-600">
+          Raw wells feed catalytic refinement into Fine EE, infuse with Fine Arcane to reach Fused, temper through Greater tools for
+          Superior, and finish the weave into Supreme. Salvage cascades on Supreme failures return Superior first, then Fused.
+        </p>
+      </section>
 
       <section className="grid gap-6 md:grid-cols-[1.6fr_1fr]">
         <div className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur">
@@ -550,18 +696,22 @@ export function NaturalEssence() {
                 className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1 text-sm text-slate-600 hover:border-slate-400"
                 onClick={() => {
                   const quick = window.prompt(
-                    "Quick set inventory (Raw, Fine, Fused, Superior, Supreme, RawAE)",
-                    "10,0,0,0,0,10",
+                    "Quick set inventory (Raw EE, Fine EE, Fused EE, Superior EE, Supreme EE, RawAE, Fine Arcane, Raw, Fine, Fused)",
+                    "10,0,0,0,0,4,2,10,0,0",
                   );
                   if (!quick) return;
                   const values = parseInventoryPreset(quick);
                   updateInventory({
-                    raw: values[0] ?? 0,
-                    fine: values[1] ?? 0,
-                    fused: values[2] ?? 0,
-                    superior: values[3] ?? 0,
-                    supreme: values[4] ?? 0,
+                    rawElemental: values[0] ?? 0,
+                    fineElemental: values[1] ?? 0,
+                    fusedElemental: values[2] ?? 0,
+                    superiorElemental: values[3] ?? 0,
+                    supremeElemental: values[4] ?? 0,
                     rawAE: values[5] ?? 0,
+                    fineArcane: values[6] ?? 0,
+                    raw: values[7] ?? 0,
+                    fine: values[8] ?? 0,
+                    fused: values[9] ?? 0,
                   });
                 }}
               >
@@ -607,6 +757,30 @@ export function NaturalEssence() {
                     }`}
                   >
                     {mode.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <span className="text-xs font-medium text-slate-500">Tool harness</span>
+              <div className="flex gap-2">
+                {(
+                  [
+                    { id: "standard", label: "Standard" },
+                    { id: "greater", label: "Greater" },
+                  ] as const
+                ).map((tool) => (
+                  <button
+                    key={tool.id}
+                    type="button"
+                    onClick={() => handleSettingsChange({ toolkit: tool.id })}
+                    className={`h-8 rounded-full border px-3 text-xs font-medium transition ${
+                      settings.toolkit === tool.id
+                        ? "border-amber-600 bg-amber-600 text-white"
+                        : "border-slate-200 text-slate-600 hover:border-slate-400"
+                    }`}
+                  >
+                    {tool.label}
                   </button>
                 ))}
               </div>
@@ -661,20 +835,25 @@ export function NaturalEssence() {
       </section>
 
       <section className="grid gap-6 lg:grid-cols-2">
-        {NATURAL_ACTIONS.map((action) => {
+        {ELEMENTAL_ACTIONS.map((action) => {
           const ui = uiState[action.id];
           const risk = action.risks.find((item) => item.id === ui.riskId) ?? action.risks[0];
           const batch = Math.max(1, ui.batch);
           const extra = Math.max(0, ui.extra);
           const requirement = inventoryRequirements[action.id];
-          const missing = missingResources(requirement);
+          const missing = missingResources(requirement, action, risk, batch, extra);
           const feasibleCount = maxFeasibleAttempts(inventory, risk, 9999, extra, action.optionalCost);
-          const canRun = batch > 0 && batch <= feasibleCount && missing.length === 0;
+          const needsGreater = risk.toolRequirement?.id === "greater" && settings.toolkit !== "greater";
+          const canRun = batch > 0 && batch <= feasibleCount && missing.length === 0 && !needsGreater;
           const odds = computeOdds(risk, settings.craftingMod, settings.rollMode, extra, action.optionalCost);
           const expectation = computeExpectedValue(risk, odds, action.optionalCost, extra);
           const wastedDc =
             action.optionalCost && extra > 0 && computeEffectiveDc(risk, extra, action.optionalCost) === action.optionalCost.minDc;
-          const missingTooltip = missing.length > 0 ? `Needs ${missing.join(", ")}` : "Run action";
+          const missingTooltip = needsGreater
+            ? "Greater tool harness required."
+            : missing.length > 0
+              ? `Needs ${missing.join(", ")}`
+              : "Run action";
 
           return (
             <article
@@ -752,6 +931,11 @@ export function NaturalEssence() {
                           <span className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-emerald-700">
                             Feasible: ×{feasibleCount}
                           </span>
+                          {needsGreater && (
+                            <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-amber-700">
+                              Need: Greater tools
+                            </span>
+                          )}
                           {missing.length > 0 && (
                             <span className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50 px-2 py-0.5 text-rose-700">
                               Need: {missing.join(", ")}
@@ -825,12 +1009,79 @@ export function NaturalEssence() {
                       DC after reduction: {computeEffectiveDc(risk, extra, action.optionalCost)} (min {action.optionalCost.minDc})
                     </div>
                   )}
-                  {renderRequirement(action.id)}
+                  {renderRequirement(action, risk, requirement, batch, extra)}
                 </div>
               </div>
             </article>
           );
         })}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white/85 p-5 shadow-sm backdrop-blur">
+        <h2 className="mb-3 text-lg font-semibold text-slate-800">Elemental codex</h2>
+        <p className="text-sm text-slate-600">
+          Elemental essence is siphoned from fault lines between planes, saturated with static arcana. Refiners must balance the
+          primal charge with borrowed essences to keep the lattice intact—RawAE only eases the T4 tempering, and Supreme elevation
+          backfeeds salvage in cascading steps.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[640px] table-fixed border-collapse text-left text-xs text-slate-600">
+            <thead>
+              <tr className="border-b border-slate-200 text-slate-500">
+                <th className="px-3 py-2 font-semibold">Tier</th>
+                <th className="px-3 py-2 font-semibold">Recipe</th>
+                <th className="px-3 py-2 font-semibold">Check DCs</th>
+                <th className="px-3 py-2 font-semibold">Salvage</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-slate-100">
+                <td className="px-3 py-2 font-semibold text-slate-700">T1</td>
+                <td className="px-3 py-2">Vent extraction → +1 or +2 Raw EE and +1 RawAE</td>
+                <td className="px-3 py-2">10 (steady) / 16 (surge)</td>
+                <td className="px-3 py-2">DC 12/14 → +1 Raw EE</td>
+              </tr>
+              <tr className="border-b border-slate-100">
+                <td className="px-3 py-2 font-semibold text-slate-700">T2</td>
+                <td className="px-3 py-2">1 Raw EE + 1 Raw (any family) → 1 Fine EE</td>
+                <td className="px-3 py-2">14</td>
+                <td className="px-3 py-2">DC 12 → +1 Raw EE</td>
+              </tr>
+              <tr className="border-b border-slate-100">
+                <td className="px-3 py-2 font-semibold text-slate-700">T3</td>
+                <td className="px-3 py-2">1 Fine EE + 1 Fine Arcane → 1 Fused EE</td>
+                <td className="px-3 py-2">18</td>
+                <td className="px-3 py-2">DC 14 → +1 Fine EE</td>
+              </tr>
+              <tr className="border-b border-slate-100">
+                <td className="px-3 py-2 font-semibold text-slate-700">T4</td>
+                <td className="px-3 py-2">1 Fused EE + 1 Fused (any family) → 1 Superior EE</td>
+                <td className="px-3 py-2">20 / 26 (−2 DC per RawAE, min 12)</td>
+                <td className="px-3 py-2">DC 16 → +2 Fine EE / DC 18 → +1 Fine EE</td>
+              </tr>
+              <tr>
+                <td className="px-3 py-2 font-semibold text-slate-700">T5</td>
+                <td className="px-3 py-2">1 Superior EE + 1 Fused EE → 1 Supreme EE</td>
+                <td className="px-3 py-2">24</td>
+                <td className="px-3 py-2">DC 22 → +1 Superior EE → else DC 18 → +1 Fused EE</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className="mt-3 text-xs text-slate-600">
+          RawAE boosters may only be spent on T4, granting −2 DC each (to a minimum of 12) and are logged per attempt. Supreme
+          salvage rolls resolve in sequence—success on the first recovers Superior EE and aborts the second roll; only a double
+          failure loses the batch entirely.
+        </div>
+        <div className="mt-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Cross-essence constraints</h3>
+          <ul className="mt-2 list-disc space-y-1 pl-6 text-xs text-slate-600">
+            <li>T2 consumes one Raw essence from any family in addition to Raw EE.</li>
+            <li>T3 requires stocked Fine Arcane catalysts; no substitutes allowed.</li>
+            <li>T4 accepts any fused essence as the second input but demands a greater tool harness.</li>
+            <li>T5 binds Superior EE with Fused EE (elemental) before rolling salvage in two stages.</li>
+          </ul>
+        </div>
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur">
@@ -860,4 +1111,4 @@ export function NaturalEssence() {
   );
 }
 
-export default NaturalEssence;
+export default ElementalEssence;

--- a/src/features/elemental/elementalRules.ts
+++ b/src/features/elemental/elementalRules.ts
@@ -1,0 +1,169 @@
+import type { ActionConfig } from "@/lib/rules/types";
+
+export const ELEMENTAL_ACTIONS: ActionConfig[] = [
+  {
+    id: "t1",
+    tier: "T1",
+    family: "elemental",
+    title: "Extract Elemental Wells",
+    subtitle: "Tap planar vents to gather raw elemental essence alongside volatile arcane residue.",
+    gradient: { from: "from-cyan-500", to: "to-blue-600" },
+    risks: [
+      {
+        id: "steady",
+        label: "Steady channel",
+        description: "DC 10 • Outputs: +1 Raw EE & +1 RawAE • Salvage: DC 12 → +1 Raw EE",
+        baseDc: 10,
+        inputs: {},
+        outputs: { rawElemental: 1, rawAE: 1 },
+        salvage: { dc: 12, returns: { rawElemental: 1 } },
+        timeMinutes: 45,
+      },
+      {
+        id: "surge",
+        label: "Surge tapping",
+        description: "DC 16 • Outputs: +2 Raw EE & +1 RawAE • Salvage: DC 14 → +1 Raw EE",
+        baseDc: 16,
+        inputs: {},
+        outputs: { rawElemental: 2, rawAE: 1 },
+        salvage: { dc: 14, returns: { rawElemental: 1 } },
+        timeMinutes: 60,
+      },
+    ],
+  },
+  {
+    id: "t2",
+    tier: "T2",
+    family: "elemental",
+    title: "Catalyze Raw → Fine",
+    subtitle: "Fuse elemental motes with any raw essence to stabilize fine elemental essence.",
+    gradient: { from: "from-teal-500", to: "to-emerald-600" },
+    risks: [
+      {
+        id: "standard",
+        label: "Catalytic mix",
+        description: "DC 14 • 1 Raw EE + 1 Raw (any family) → 1 Fine EE • Salvage: DC 12 → +1 Raw EE",
+        baseDc: 14,
+        inputs: { rawElemental: 1 },
+        flexInputs: [
+          {
+            id: "raw-any",
+            label: "Raw essence (any family)",
+            amount: 1,
+            options: ["raw", "rawElemental"],
+          },
+        ],
+        outputs: { fineElemental: 1 },
+        salvage: { dc: 12, returns: { rawElemental: 1 } },
+        timeMinutes: 90,
+      },
+    ],
+  },
+  {
+    id: "t3",
+    tier: "T3",
+    family: "elemental",
+    title: "Infuse Fine + Arcane",
+    subtitle: "Blend elemental essence with fine arcane catalysts to create fused essence.",
+    gradient: { from: "from-indigo-500", to: "to-purple-600" },
+    risks: [
+      {
+        id: "infuse",
+        label: "Arcane infusion",
+        description: "DC 18 • 1 Fine EE + 1 Fine Arcane → 1 Fused EE • Salvage: DC 14 → +1 Fine EE",
+        baseDc: 18,
+        inputs: { fineElemental: 1, fineArcane: 1 },
+        outputs: { fusedElemental: 1 },
+        salvage: { dc: 14, returns: { fineElemental: 1 } },
+        timeMinutes: 120,
+      },
+    ],
+  },
+  {
+    id: "t4",
+    tier: "T4",
+    family: "elemental",
+    title: "Refine Fused → Superior",
+    subtitle: "Channel fused essence through greater tools; spend RawAE to ease the DC.",
+    gradient: { from: "from-rose-500", to: "to-orange-600" },
+    optionalCost: {
+      resource: "rawAE",
+      label: "RawAE boosters (−2 DC each)",
+      perUnitDcReduction: 2,
+      minDc: 12,
+    },
+    risks: [
+      {
+        id: "steady",
+        label: "Careful tempering",
+        description: "Base DC 20 • 1 Fused EE + 1 Fused (any family) → 1 Superior EE • Salvage: DC 16 → +2 Fine EE",
+        baseDc: 20,
+        inputs: { fusedElemental: 1 },
+        flexInputs: [
+          {
+            id: "fused-any",
+            label: "Fused essence (any family)",
+            amount: 1,
+            options: ["fused", "fusedElemental"],
+          },
+        ],
+        outputs: { superiorElemental: 1 },
+        salvage: { dc: 16, returns: { fineElemental: 2 } },
+        toolRequirement: {
+          id: "greater",
+          label: "Requires greater elemental condenser",
+          description: "Superior refinement needs a greater-grade tool set.",
+        },
+        timeMinutes: 150,
+      },
+      {
+        id: "surge",
+        label: "Aggressive channel",
+        description: "Base DC 26 • 1 Fused EE + 1 Fused (any family) → 1 Superior EE • Salvage: DC 18 → +1 Fine EE",
+        baseDc: 26,
+        inputs: { fusedElemental: 1 },
+        flexInputs: [
+          {
+            id: "fused-any",
+            label: "Fused essence (any family)",
+            amount: 1,
+            options: ["fused", "fusedElemental"],
+          },
+        ],
+        outputs: { superiorElemental: 1 },
+        salvage: { dc: 18, returns: { fineElemental: 1 } },
+        toolRequirement: {
+          id: "greater",
+          label: "Requires greater elemental condenser",
+        },
+        timeMinutes: 210,
+      },
+    ],
+  },
+  {
+    id: "t5",
+    tier: "T5",
+    family: "elemental",
+    title: "Elevate Superior → Supreme",
+    subtitle: "Complete the cycle by marrying superior and fused elemental essence.",
+    gradient: { from: "from-amber-500", to: "to-red-600" },
+    risks: [
+      {
+        id: "ascend",
+        label: "Ascension weave",
+        description:
+          "DC 24 • 1 Superior EE + 1 Fused EE → 1 Supreme EE • Salvage: DC 22 → +1 Superior EE / DC 18 → +1 Fused EE",
+        baseDc: 24,
+        inputs: { superiorElemental: 1, fusedElemental: 1 },
+        outputs: { supremeElemental: 1 },
+        salvage: {
+          stages: [
+            { dc: 22, returns: { superiorElemental: 1 } },
+            { dc: 18, returns: { fusedElemental: 1 } },
+          ],
+        },
+        timeMinutes: 240,
+      },
+    ],
+  },
+];

--- a/src/lib/rules/__tests__/runner.test.ts
+++ b/src/lib/rules/__tests__/runner.test.ts
@@ -5,8 +5,9 @@ import {
   computeExpectedValue,
   computeOdds,
   maxFeasibleAttempts,
+  runAction,
 } from "@/lib/rules/runner";
-import type { OptionalCostConfig, RiskConfig } from "@/lib/rules/types";
+import type { ActionConfig, Inventory, OptionalCostConfig, RiskConfig } from "@/lib/rules/types";
 
 const baseRisk: RiskConfig = {
   id: "standard",
@@ -26,6 +27,22 @@ const optional: OptionalCostConfig = {
   minDc: 5,
 };
 
+const makeInventory = (patch: Partial<Inventory> = {}): Inventory => ({
+  raw: 0,
+  fine: 0,
+  fused: 0,
+  superior: 0,
+  supreme: 0,
+  rawAE: 0,
+  rawElemental: 0,
+  fineElemental: 0,
+  fusedElemental: 0,
+  superiorElemental: 0,
+  supremeElemental: 0,
+  fineArcane: 0,
+  ...patch,
+});
+
 describe("computeEffectiveDc", () => {
   it("clamps to minimum DC", () => {
     expect(computeEffectiveDc(baseRisk, 0, optional)).toBe(18);
@@ -37,7 +54,7 @@ describe("computeEffectiveDc", () => {
 
 describe("maxFeasibleAttempts", () => {
   it("accounts for multiple resources and optional costs", () => {
-    const inventory = { raw: 0, fine: 0, fused: 10, superior: 0, supreme: 0, rawAE: 3 };
+    const inventory = makeInventory({ fused: 10, rawAE: 3 });
     expect(maxFeasibleAttempts(inventory, baseRisk, 5, 1, optional)).toBe(3);
     expect(maxFeasibleAttempts(inventory, baseRisk, 5, 0, optional)).toBe(5);
   });
@@ -47,7 +64,7 @@ describe("maxFeasibleAttempts", () => {
       ...baseRisk,
       inputs: {},
     };
-    const inventory = { raw: 0, fine: 0, fused: 0, superior: 0, supreme: 0, rawAE: 0 };
+    const inventory = makeInventory();
     expect(maxFeasibleAttempts(inventory, freeRisk, 4, 0, undefined)).toBe(4);
   });
 
@@ -62,8 +79,27 @@ describe("maxFeasibleAttempts", () => {
       perUnitDcReduction: 1,
       minDc: 10,
     };
-    const inventory = { raw: 0, fine: 0, fused: 5, superior: 0, supreme: 0, rawAE: 0 };
+    const inventory = makeInventory({ fused: 5 });
     expect(maxFeasibleAttempts(inventory, sharedResourceRisk, 10, 1, sharedOptional)).toBe(1);
+  });
+
+  it("respects flex inputs when computing feasibility", () => {
+    const flexRisk: RiskConfig = {
+      ...baseRisk,
+      inputs: { rawElemental: 1 },
+      outputs: { fineElemental: 1 },
+      salvage: undefined,
+      flexInputs: [
+        {
+          id: "raw-any",
+          label: "Raw essence (any family)",
+          amount: 1,
+          options: ["raw", "rawElemental"],
+        },
+      ],
+    };
+    const inventory = makeInventory({ rawElemental: 2, raw: 2 });
+    expect(maxFeasibleAttempts(inventory, flexRisk, 5, 0, undefined)).toBe(2);
   });
 });
 
@@ -91,5 +127,62 @@ describe("computeExpectedValue", () => {
     expect(expectation.superior).toBeGreaterThan(0);
     expect(expectation.fused).toBeLessThan(0);
     expect(expectation.rawAE).toBe(-1);
+  });
+});
+
+describe("runAction staged salvage", () => {
+  const stagedAction: ActionConfig = {
+    id: "staged",
+    tier: "T5",
+    title: "Test",
+    subtitle: "",
+    gradient: { from: "", to: "" },
+    risks: [
+      {
+        id: "staged",
+        label: "Staged",
+        baseDc: 24,
+        inputs: { superiorElemental: 1, fusedElemental: 1 },
+        outputs: { supremeElemental: 1 },
+        salvage: {
+          stages: [
+            { dc: 22, returns: { superiorElemental: 1 } },
+            { dc: 18, returns: { fusedElemental: 1 } },
+          ],
+        },
+        timeMinutes: 120,
+      },
+    ],
+  };
+
+  it("applies staged salvage sequentially", () => {
+    const risk = stagedAction.risks[0];
+    const strategy = {
+      salvageRolls: [5, 18],
+      nextCheckPair: (): [number, number] => [1, 1],
+      nextSalvage() {
+        return this.salvageRolls.shift() ?? 1;
+      },
+    };
+
+    const result = runAction({
+      action: stagedAction,
+      risk,
+      attempts: 1,
+      inventory: makeInventory({ superiorElemental: 1, fusedElemental: 1 }),
+      modifier: 0,
+      rollMode: "normal",
+      rollStrategy: strategy,
+      extraCost: 0,
+    });
+
+    expect(result.attempts).toHaveLength(1);
+    const attempt = result.attempts[0];
+    const stages = Array.isArray(attempt.salvage) ? attempt.salvage : [];
+    expect(stages).toHaveLength(2);
+    expect(stages[0].success).toBe(false);
+    expect(stages[1].success).toBe(true);
+    expect(result.finalInventory.fusedElemental).toBe(1);
+    expect(result.finalInventory.superiorElemental).toBe(0);
   });
 });

--- a/src/lib/rules/runner.ts
+++ b/src/lib/rules/runner.ts
@@ -10,6 +10,8 @@ import type {
   ResourceMap,
   RiskConfig,
   RollDetail,
+  SalvageConfig,
+  SalvageStage,
 } from "./types";
 
 export interface RollStrategy {
@@ -28,14 +30,101 @@ export interface RunOptions {
   extraCost?: number;
 }
 
-export const RESOURCE_ORDER: Resource[] = ["raw", "fine", "fused", "superior", "supreme", "rawAE"];
+export const RESOURCE_ORDER: Resource[] = [
+  "raw",
+  "fine",
+  "fused",
+  "superior",
+  "supreme",
+  "rawAE",
+  "rawElemental",
+  "fineElemental",
+  "fusedElemental",
+  "superiorElemental",
+  "supremeElemental",
+  "fineArcane",
+];
 
 export function cloneInventory(source: Inventory): Inventory {
-  const clone: Inventory = { raw: 0, fine: 0, fused: 0, superior: 0, supreme: 0, rawAE: 0 };
+  const clone: Inventory = {
+    raw: 0,
+    fine: 0,
+    fused: 0,
+    superior: 0,
+    supreme: 0,
+    rawAE: 0,
+    rawElemental: 0,
+    fineElemental: 0,
+    fusedElemental: 0,
+    superiorElemental: 0,
+    supremeElemental: 0,
+    fineArcane: 0,
+  };
   for (const key of RESOURCE_ORDER) {
     clone[key] = source[key] ?? 0;
   }
   return clone;
+}
+
+function resolveAttemptRequirement(
+  inventory: Inventory,
+  risk: RiskConfig,
+  extraCost: number,
+  optional?: OptionalCostConfig,
+): ResourceMap | null {
+  const available = cloneInventory(inventory);
+  const requirement: ResourceMap = {};
+
+  for (const key of Object.keys(risk.inputs) as Resource[]) {
+    const need = risk.inputs[key] ?? 0;
+    if (need <= 0) continue;
+    if ((available[key] ?? 0) < need) {
+      return null;
+    }
+    available[key] -= need;
+    requirement[key] = (requirement[key] ?? 0) + need;
+  }
+
+  if (optional && extraCost > 0) {
+    const resource = optional.resource;
+    if ((available[resource] ?? 0) < extraCost) {
+      return null;
+    }
+    available[resource] -= extraCost;
+    requirement[resource] = (requirement[resource] ?? 0) + extraCost;
+  }
+
+  for (const flex of risk.flexInputs ?? []) {
+    let remaining = flex.amount;
+    for (const option of flex.options) {
+      const usable = Math.min(remaining, available[option] ?? 0);
+      if (usable > 0) {
+        available[option] -= usable;
+        requirement[option] = (requirement[option] ?? 0) + usable;
+        remaining -= usable;
+      }
+      if (remaining <= 0) break;
+    }
+    if (remaining > 0) {
+      return null;
+    }
+  }
+
+  return requirement;
+}
+
+function applyRequirement(target: Inventory, requirement: ResourceMap) {
+  for (const key of Object.keys(requirement) as Resource[]) {
+    target[key] -= requirement[key] ?? 0;
+  }
+}
+
+function resolveSalvageStages(config?: SalvageConfig): SalvageStage[] {
+  if (!config) return [];
+  if ("stages" in config) {
+    return config.stages;
+  }
+  return [config];
 }
 
 export function computeEffectiveDc(risk: RiskConfig, extraCost: number, optional?: OptionalCostConfig): number {
@@ -57,38 +146,26 @@ export function totalRequirements(risk: RiskConfig, attempts: number, extraCost:
   return requirements;
 }
 
-export function maxFeasibleAttempts(inventory: Inventory, risk: RiskConfig, attempts: number, extraCost: number, optional?: OptionalCostConfig): number {
-  const perAttempt = totalRequirements(risk, 1, extraCost, optional);
-  let feasible = attempts;
-  let hasCost = false;
+export function maxFeasibleAttempts(
+  inventory: Inventory,
+  risk: RiskConfig,
+  attempts: number,
+  extraCost: number,
+  optional?: OptionalCostConfig,
+): number {
+  const working = cloneInventory(inventory);
+  let feasible = 0;
 
-  for (const key of Object.keys(perAttempt) as Resource[]) {
-    const cost = perAttempt[key] ?? 0;
-    if (cost <= 0) {
-      continue;
+  for (let i = 0; i < attempts; i++) {
+    const requirement = resolveAttemptRequirement(working, risk, extraCost, optional);
+    if (!requirement) {
+      break;
     }
-
-    hasCost = true;
-    const available = inventory[key] ?? 0;
-    feasible = Math.min(feasible, Math.floor(available / cost));
+    applyRequirement(working, requirement);
+    feasible += 1;
   }
 
-  if (!hasCost) {
-    return Math.max(0, attempts);
-  }
-
-  return Math.max(0, feasible);
-}
-
-function requirementMet(inventory: Inventory, delta: ResourceMap): boolean {
-  for (const key of Object.keys(delta) as Resource[]) {
-    const need = delta[key] ?? 0;
-    if (need <= 0) continue;
-    if ((inventory[key] ?? 0) < need) {
-      return false;
-    }
-  }
-  return true;
+  return feasible;
 }
 
 export function runAction(options: RunOptions): ActionRunResult {
@@ -100,19 +177,13 @@ export function runAction(options: RunOptions): ActionRunResult {
   let stoppedReason: string | undefined;
 
   for (let i = 0; i < attempts; i++) {
-    const requirement = totalRequirements(risk, 1, extraCost, action.optionalCost);
-    if (!requirementMet(finalInventory, requirement)) {
+    const requirement = resolveAttemptRequirement(finalInventory, risk, extraCost, action.optionalCost);
+    if (!requirement) {
       stoppedReason = "Insufficient resources";
       break;
     }
 
-    // consume inputs
-    for (const key of Object.keys(risk.inputs) as Resource[]) {
-      finalInventory[key] -= risk.inputs[key] ?? 0;
-    }
-    if (action.optionalCost && extraCost > 0) {
-      finalInventory[action.optionalCost.resource] -= extraCost;
-    }
+    applyRequirement(finalInventory, requirement);
 
     const [rollA, rollB] = rollStrategy.nextCheckPair();
     const pick = pickAdvantage({ roll: rollA, other: rollB }, rollMode);
@@ -133,16 +204,14 @@ export function runAction(options: RunOptions): ActionRunResult {
     };
 
     const delta: ResourceMap = {};
+    for (const key of Object.keys(requirement) as Resource[]) {
+      delta[key] = (delta[key] ?? 0) - (requirement[key] ?? 0);
+    }
     if (success) {
       for (const key of Object.keys(risk.outputs) as Resource[]) {
         const gain = risk.outputs[key] ?? 0;
         finalInventory[key] += gain;
         delta[key] = (delta[key] ?? 0) + gain;
-      }
-    } else {
-      for (const key of Object.keys(risk.salvage?.returns ?? {}) as Resource[]) {
-        const salvageAmount = risk.salvage?.returns[key] ?? 0;
-        delta[key] = (delta[key] ?? 0) + 0; // placeholder to ensure key exists
       }
     }
 
@@ -160,39 +229,43 @@ export function runAction(options: RunOptions): ActionRunResult {
     allRolls.push(check);
 
     if (!success && risk.salvage) {
-      const salvageRoll = rollStrategy.nextSalvage();
-      const salvageTotal = salvageRoll + modifier;
-      const salvageSuccess = salvageTotal >= risk.salvage.dc;
-      const salvage: RollDetail = {
-        type: "salvage",
-        tier: action.tier,
-        actionId: action.id,
-        riskId: risk.id,
-        dc: risk.salvage.dc,
-        die: salvageRoll,
-        modifier,
-        total: salvageTotal,
-        success: salvageSuccess,
-      };
-      attempt.salvage = salvage;
-      allRolls.push(salvage);
+      const stages = resolveSalvageStages(risk.salvage);
+      const salvageRolls: RollDetail[] = [];
 
-      if (salvageSuccess) {
-        for (const key of Object.keys(risk.salvage.returns) as Resource[]) {
-          const gain = risk.salvage.returns[key] ?? 0;
-          finalInventory[key] += gain;
-          attempt.inventoryDelta[key] = (attempt.inventoryDelta[key] ?? 0) + gain;
+      for (let stageIndex = 0; stageIndex < stages.length; stageIndex++) {
+        const stage = stages[stageIndex];
+        const salvageRoll = rollStrategy.nextSalvage();
+        const salvageTotal = salvageRoll + modifier;
+        const salvageSuccess = salvageTotal >= stage.dc;
+        const salvage: RollDetail = {
+          type: "salvage",
+          tier: action.tier,
+          actionId: action.id,
+          riskId: risk.id,
+          dc: stage.dc,
+          die: salvageRoll,
+          modifier,
+          total: salvageTotal,
+          success: salvageSuccess,
+          stage: stageIndex + 1,
+        };
+        salvageRolls.push(salvage);
+        allRolls.push(salvage);
+
+        if (salvageSuccess) {
+          for (const key of Object.keys(stage.returns) as Resource[]) {
+            const gain = stage.returns[key] ?? 0;
+            if (!gain) continue;
+            finalInventory[key] += gain;
+            attempt.inventoryDelta[key] = (attempt.inventoryDelta[key] ?? 0) + gain;
+          }
+          break;
         }
       }
-    }
 
-    for (const key of Object.keys(risk.inputs) as Resource[]) {
-      const spent = risk.inputs[key] ?? 0;
-      attempt.inventoryDelta[key] = (attempt.inventoryDelta[key] ?? 0) - spent;
-    }
-    if (action.optionalCost && extraCost > 0) {
-      attempt.inventoryDelta[action.optionalCost.resource] =
-        (attempt.inventoryDelta[action.optionalCost.resource] ?? 0) - extraCost;
+      if (salvageRolls.length > 0) {
+        attempt.salvage = salvageRolls;
+      }
     }
 
     results.push(attempt);
@@ -218,6 +291,7 @@ export function runAction(options: RunOptions): ActionRunResult {
 export interface OddsResult {
   success: number;
   salvage?: number;
+  salvageStages?: number[];
   effectiveDc: number;
 }
 
@@ -229,9 +303,22 @@ export function computeOdds(
   optional?: OptionalCostConfig,
 ): OddsResult {
   const dc = computeEffectiveDc(risk, extraCost, optional);
+  const successChance = chanceWithAdv(dc, modifier, mode);
+  let salvageChance: number | undefined;
+  let stageChances: number[] | undefined;
+  if (risk.salvage) {
+    const stages = resolveSalvageStages(risk.salvage);
+    stageChances = stages.map((stage) => chanceNormal(stage.dc, modifier));
+    let failProduct = 1;
+    for (const chance of stageChances) {
+      failProduct *= 1 - chance;
+    }
+    salvageChance = (1 - successChance) * (1 - failProduct);
+  }
   return {
-    success: chanceWithAdv(dc, modifier, mode),
-    salvage: risk.salvage ? chanceNormal(risk.salvage.dc, modifier) : undefined,
+    success: successChance,
+    salvage: salvageChance,
+    salvageStages: stageChances,
     effectiveDc: dc,
   };
 }
@@ -242,7 +329,7 @@ export function computeExpectedValue(
   optional: OptionalCostConfig | undefined,
   extraCost: number,
 ): ResourceMap {
-  const { success, salvage } = odds;
+  const { success } = odds;
   const expectation: ResourceMap = {};
 
   for (const key of Object.keys(risk.inputs) as Resource[]) {
@@ -259,13 +346,23 @@ export function computeExpectedValue(
     if (gain) expectation[key] = (expectation[key] ?? 0) + gain * success;
   }
 
-  if (risk.salvage && salvage !== undefined) {
-    for (const key of Object.keys(risk.salvage.returns) as Resource[]) {
-      const gain = risk.salvage.returns[key] ?? 0;
-      if (!gain) continue;
-      const salvageChance = (1 - success) * salvage;
-      expectation[key] = (expectation[key] ?? 0) + gain * salvageChance;
-    }
+  if (risk.salvage && (odds.salvageStages?.length ?? 0) > 0) {
+    const stages = resolveSalvageStages(risk.salvage);
+    let remainingFailure = 1 - success;
+    stages.forEach((stage, index) => {
+      const stageChance = odds.salvageStages?.[index] ?? 0;
+      if (stageChance <= 0) {
+        remainingFailure *= 1;
+        return;
+      }
+      const actualChance = remainingFailure * stageChance;
+      for (const key of Object.keys(stage.returns) as Resource[]) {
+        const gain = stage.returns[key] ?? 0;
+        if (!gain) continue;
+        expectation[key] = (expectation[key] ?? 0) + gain * actualChance;
+      }
+      remainingFailure *= 1 - stageChance;
+    });
   }
 
   return expectation;

--- a/src/lib/rules/types.ts
+++ b/src/lib/rules/types.ts
@@ -1,4 +1,20 @@
-export type Resource = "raw" | "fine" | "fused" | "superior" | "supreme" | "rawAE";
+export type Resource =
+  | "raw"
+  | "fine"
+  | "fused"
+  | "superior"
+  | "supreme"
+  | "rawAE"
+  | "rawElemental"
+  | "fineElemental"
+  | "fusedElemental"
+  | "superiorElemental"
+  | "supremeElemental"
+  | "fineArcane";
+
+export type Tier = "T1" | "T2" | "T3" | "T4" | "T5";
+
+export type EssenceFamily = "natural" | "elemental";
 
 export type Inventory = Record<Resource, number>;
 
@@ -8,9 +24,25 @@ export type AdvMode = "normal" | "adv" | "dis";
 
 export interface ResourceMap extends Partial<Record<Resource, number>> {}
 
-export interface SalvageConfig {
+export interface SalvageStage {
   dc: number;
   returns: ResourceMap;
+  label?: string;
+}
+
+export type SalvageConfig = SalvageStage | { stages: SalvageStage[] };
+
+export interface FlexInputConfig {
+  id: string;
+  label: string;
+  amount: number;
+  options: Resource[];
+}
+
+export interface ToolRequirement {
+  id: "greater" | string;
+  label: string;
+  description?: string;
 }
 
 export interface RiskConfig {
@@ -21,6 +53,8 @@ export interface RiskConfig {
   inputs: ResourceMap;
   outputs: ResourceMap;
   salvage?: SalvageConfig;
+  flexInputs?: FlexInputConfig[];
+  toolRequirement?: ToolRequirement;
   timeMinutes: number;
 }
 
@@ -33,12 +67,13 @@ export interface OptionalCostConfig {
 
 export interface ActionConfig {
   id: string;
-  tier: string;
+  tier: Tier;
   title: string;
   subtitle: string;
   gradient: { from: string; to: string };
   risks: RiskConfig[];
   optionalCost?: OptionalCostConfig;
+  family?: EssenceFamily;
 }
 
 export interface RollDetail {
@@ -51,6 +86,7 @@ export interface RollDetail {
   modifier: number;
   total: number;
   success: boolean;
+  stage?: number;
 }
 
 export interface AttemptResult {
@@ -61,7 +97,7 @@ export interface AttemptResult {
   success: boolean;
   timeMinutes: number;
   check: RollDetail;
-  salvage?: RollDetail;
+  salvage?: RollDetail | RollDetail[];
   inventoryDelta: ResourceMap;
   stopped?: boolean;
 }


### PR DESCRIPTION
## Summary
- add the Elemental essence feature module with progression map, inventory tooling, and codex documentation
- extend the shared rules types/runner to support elemental resources, flexible inputs, and staged salvage rolls
- wire the app-level family switcher and cover the new engine behaviors with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f3d8a2d3208333acf172c89129f811